### PR TITLE
Фикс бага со сменой жанров #145

### DIFF
--- a/frontend/src/Components/blocks/FilmList/styles.ts
+++ b/frontend/src/Components/blocks/FilmList/styles.ts
@@ -8,5 +8,6 @@ export const DivFilmList = styled(Div)`
 
 	width: 100%;
 	width: 1050px;
+	min-height: 170px;
 `;
 


### PR DESCRIPTION
- добавлена минимальная высота контейнера с фильмами, чтобы избежать скачков вёрстки
при быстрой смене жанров